### PR TITLE
Use Type Arguments Over Passed-In Type

### DIFF
--- a/src/Library.fs
+++ b/src/Library.fs
@@ -6,38 +6,37 @@ module SnazzGen =
     open System.Text
     open System.Text.RegularExpressions
     open System.Reflection
-    
-    exception SnazzGenTypeError of string
-    
+
     type SnazzMeta =
         | Meta of PrimaryKey:string
         | MetaSetBytea of PrimaryKey:string
         | MetaSetTable of PrimaryKey:string * TableName:string
         | MetaSetTableBytea of PrimaryKey:string * TableName:string
-    
+
     let CamelCasePattern = Regex(@"[A-Z]{2,}(?=[A-Z][a-z]+[0-9]*|\b)|[A-Z]?[a-z]+[0-9]*|[A-Z]|[0-9]+")
     let ValuesClausePattern = Regex(@"(?<= VALUES ).+")
 
     let transformDotnetNameToSQL (propertyName:string) =
         String.Join("_", CamelCasePattern.Matches(propertyName)).ToLower()
 
-    let getValueFromProperty (property:PropertyInfo) (bytea:bool) = 
-            if bytea && (property.PropertyType = Type.GetType("System.Byte[]")) then
+    let getValueFromProperty (property:PropertyInfo) (bytea:bool) =
+            if bytea && (property.PropertyType = typeof<Byte[]>) then
                 "@" + property.Name + "::bytea"
             else
                 "@" + property.Name
 
-    let setMeta (typeInstance:Type) (meta:SnazzMeta) =
+    let setMeta<'Type> (meta:SnazzMeta) =
+        let typeInstance = typeof<'Type>
         match meta with
             | MetaSetTable(key, table) -> (key, table, false)
             | MetaSetTableBytea(key, table) -> (key, table, true)
             | Meta(key) -> (key, (transformDotnetNameToSQL typeInstance.Name), false)
             | MetaSetBytea(key) -> (key, (transformDotnetNameToSQL typeInstance.Name), true)
-    
-    let buildInsert (typeInstance:Type) (meta:SnazzMeta) =
-        if (typeInstance = null) then
-            raise (SnazzGenTypeError "Error: Type provided to mapper is null.")
-        let primaryKey, tableName, bytea = setMeta typeInstance meta
+
+    let buildInsert<'Type> (meta:SnazzMeta) =
+        let typeInstance = typeof<'Type>
+
+        let primaryKey, tableName, bytea = setMeta<'Type> meta
         let props = typeInstance.GetProperties()
         let statement = StringBuilder()
         let statement = statement.Append("INSERT INTO " + tableName)
@@ -47,13 +46,15 @@ module SnazzGen =
             if prop.Name <> primaryKey then
                 fields.Add(transformDotnetNameToSQL prop.Name)
                 values.Add(getValueFromProperty prop bytea)
-        let statement = statement.Append(" (")
-        let statement = statement.Append(String.Join(", ", fields))
-        let statement = statement.Append(") VALUES (")
-        let statement = statement.Append(String.Join(", ", values))
-        let statement = statement.Append(")")
-        statement.ToString()
-    
+
+        statement
+            .Append(" (")
+            .Append(String.Join(", ", fields))
+            .Append(") VALUES (")
+            .Append(String.Join(", ", values))
+            .Append(")")
+        |> string
+
     let makeInsertBulk insertStatement rows =
         let valuesClause = ValuesClausePattern.Match(insertStatement).Value
         insertStatement + ", " + String.Join(", ", List.replicate (rows - 1) valuesClause) + ";"

--- a/tests/Tests.fs
+++ b/tests/Tests.fs
@@ -16,34 +16,30 @@ type Photo = {
 
 [<Fact>]
 let ``Mapper generates correct SQL`` () =
-    let sql = SnazzGen.buildInsert (typeof<Photo>) (SnazzGen.Meta("Id"))
+    let sql = SnazzGen.buildInsert<Photo> (SnazzGen.Meta("Id"))
     let expected = "INSERT INTO photo (name, author, location, binary_data, comma_separated_tags, likes) VALUES (@Name, @Author, @Location, @BinaryData, @CommaSeparatedTags, @Likes)"
     Assert.Equal(expected, sql)
 [<Fact>]
 let ``Mapper generates correct SQL using bytea`` () =
-    let sql = SnazzGen.buildInsert (typeof<Photo>) (SnazzGen.MetaSetBytea("Id"))
+    let sql = SnazzGen.buildInsert<Photo> (SnazzGen.MetaSetBytea("Id"))
     let expected = "INSERT INTO photo (name, author, location, binary_data, comma_separated_tags, likes) VALUES (@Name, @Author, @Location, @BinaryData::bytea, @CommaSeparatedTags, @Likes)"
     Assert.Equal(expected, sql)
 
-[<Fact>]    
+[<Fact>]
 let ``Mapper generates correct SQL with custom table name`` () =
-    let sql = SnazzGen.buildInsert (typeof<Photo>) (SnazzGen.MetaSetTable("Id", "photographs"))
+    let sql = SnazzGen.buildInsert<Photo> (SnazzGen.MetaSetTable("Id", "photographs"))
     let expected = "INSERT INTO photographs (name, author, location, binary_data, comma_separated_tags, likes) VALUES (@Name, @Author, @Location, @BinaryData, @CommaSeparatedTags, @Likes)"
     Assert.Equal(expected, sql)
 
-[<Fact>]    
+[<Fact>]
 let ``Mapper generates correct SQL with custom table name with bytea`` () =
-    let sql = SnazzGen.buildInsert (typeof<Photo>) (SnazzGen.MetaSetTableBytea("Id", "photographs"))
+    let sql = SnazzGen.buildInsert<Photo> (SnazzGen.MetaSetTableBytea("Id", "photographs"))
     let expected = "INSERT INTO photographs (name, author, location, binary_data, comma_separated_tags, likes) VALUES (@Name, @Author, @Location, @BinaryData::bytea, @CommaSeparatedTags, @Likes)"
     Assert.Equal(expected, sql)
 
 [<Fact>]
-let ``Mapper fails on null type`` () =
-    Assert.Throws<SnazzGen.SnazzGenTypeError>(fun() -> (SnazzGen.buildInsert null (SnazzGen.Meta("Id"))) |> ignore) |> ignore
-
-[<Fact>]
 let ``Mapper turns insert into bulk insert correctly`` () =
-    let initialSql = SnazzGen.buildInsert (typeof<Photo>) (SnazzGen.MetaSetBytea("Id"))
+    let initialSql = SnazzGen.buildInsert<Photo> (SnazzGen.MetaSetBytea("Id"))
     let sql = SnazzGen.makeInsertBulk initialSql 5
     let expected = StringBuilder("INSERT INTO photo (name, author, location, binary_data, comma_separated_tags, likes)")
     expected.Append(" VALUES (@Name, @Author, @Location, @BinaryData::bytea, @CommaSeparatedTags, @Likes)") |> ignore


### PR DESCRIPTION
By using generics, we remove the need for a null check as well as making it more idiomatic and programmer-friendly. In addition, using `typeof<Byte[]>` is far safer than retrieving the type using the string name. There are some other issues to note that I haven't addressed:

- If a collection is passed in, undefined behavior will likely occur as it will be treating the collection as the type to insert
- [The Bulk Insert piece is entirely unnecessary, see Marc' comment](https://stackoverflow.com/a/17150843/2396111) (as it pertains to Dapper, for SqlCommand et. al., it is perfectly valid)
- Not everyone's naming scheme will be the same as yours, so `transformDotnetNameToSQL` could potentially cause problems if anyone besides yourself were to use the library